### PR TITLE
COOK-786: fix chef_environment to be used as attribute in django recipe

### DIFF
--- a/recipes/django.rb
+++ b/recipes/django.rb
@@ -1,4 +1,4 @@
-#
+ #
 # Cookbook Name:: application
 # Recipe:: django
 #
@@ -155,7 +155,7 @@ deploy_revision app['id'] do
   before_migrate do
     requirements_file = nil
     # look for requirements.txt files in common locations
-    if ::File.exists?(::File.join(release_path, "requirements", "#{node[:chef_environment]}.txt"))
+    if ::File.exists?(::File.join(release_path, "requirements", "#{node.chef_environment}.txt"))
       requirements_file = ::File.join(release_path, "requirements", "#{node.chef_environment}.txt")
     elsif ::File.exists?(::File.join(release_path, "requirements.txt"))
       requirements_file = ::File.join(release_path, "requirements.txt")


### PR DESCRIPTION
recreates the change in:
https://github.com/ches/cookbooks/commit/520717cbc609891cae563ce419ff2041e3ff99fb
