### PR TITLE
Remove application recipes from 'seen_recipes' so they can be applied multiple times

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,10 +21,11 @@ search(:apps) do |app|
   (app["server_roles"] & node.run_list.roles).each do |app_role|
     app["type"][app_role].each do |thing|
       node.run_state[:current_app] = app
+      # Allow application recipes to run multiple times
+      node.run_state[:seen_recipes].delete("application::#{thing}")
       include_recipe "application::#{thing}"
     end
   end
 end
 
 node.run_state.delete(:current_app)
-


### PR DESCRIPTION
This patch removes application recipes from 'seen_recipes' to apply application recipes (and thus "applications") multiple times on a node.

A common example is to have multiple web applications with different document roots and "context" on one machine.

Currently this is not possible because a application cookbook is only applied once as stated on http://wiki.opscode.com/display/chef/Recipes: _Note, however, that subsequent calls to include_recipe for the same recipe will have no effect._ 

Do you see any downsides in applying the patch? Or is there another way in applying similar application cookbooks onto one node?

Cheers

Christian
