### PR TITLE
[COOK-1332] Add #release_path and #shared_path convenience methods on the main application resource, so that users don't need to jump through hoops.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -71,10 +71,6 @@ class Chef
         end
       end
 
-      def release_path
-        application_provider.release_path
-      end
-
       class OptionsBlock
         include Chef::Resource::Application::OptionsCollector
       end
@@ -135,13 +131,20 @@ class Chef
         klass.extend Chef::Mixin::FromFile
       end
 
-      def release_path
-        if !@deploy_provider
-          #@deploy_provider = Chef::Platform.provider_for_resource(@run_context.resource_collection.find(:deploy_revision => @new_resource.id))
-          @deploy_provider = Chef::Platform.provider_for_resource(@deploy_resource)
-          @deploy_provider.load_current_resource
+      def deploy_provider
+        @deploy_provider ||= begin
+          deploy_provider = Chef::Platform.provider_for_resource(@deploy_resource)
+          deploy_provider.load_current_resource
+          deploy_provider
         end
-        @deploy_provider.release_path
+      end
+
+      def release_path
+        deploy_provider.release_path
+      end
+
+      def shared_path
+        @deploy_resource.shared_path
       end
 
       def callback(what, callback_code=nil)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -57,6 +57,7 @@ end
 protected
 
 def before_compile
+  new_resource.application_provider self
   new_resource.sub_resources.each do |resource|
     resource.application_provider self
     resource.run_action :before_compile

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -51,6 +51,7 @@ attribute :migrate, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :migration_command, :kind_of => [String, NilClass], :default => nil
 attribute :restart_command, :kind_of => [String, NilClass], :default => nil
 attribute :packages, :kind_of => [Array, Hash], :default => []
+attribute :application_provider
 attr_reader :sub_resources
 
 # Callback fires before deploy is started.
@@ -81,6 +82,14 @@ end
 def after_restart(arg=nil, &block)
   arg ||= block
   set_or_return(:after_restart, arg, :kind_of => [Proc, String])
+end
+
+def release_path
+  application_provider.release_path
+end
+
+def shared_path
+  application_provider.shared_path
 end
 
 def method_missing(name, *args, &block)


### PR DESCRIPTION
Kudos to David Joos for extra testing.
