### PR TITLE
Adding a custom cookbook

### DIFF
--- a/recipes/passenger_apache2.rb
+++ b/recipes/passenger_apache2.rb
@@ -35,7 +35,13 @@ end
 web_app app['id'] do
   docroot "#{app['deploy_to']}/current/public"
   template "#{app['id']}.conf.erb"
-  cookbook "#{app['id']}"
+
+  if cookbook app['cookbooks'] && app['cookbooks'][app['id']]
+    cookbook app['cookbooks'][app['id']]
+  else
+    cookbook app['id']
+  end
+
   server_name "#{app['id']}.#{node[:domain]}"
   server_aliases server_aliases
   log_dir node[:apache][:log_dir]


### PR DESCRIPTION
Currently I didn't see a way to group application configurations under one cookbook. Even though in most cases, having one cookbook per application fits, there are cases where one needs to group them under one parent cookbook.

This commit introduces a apps['cookbooks'] entry into the Data bag and tries to map to correct cookbook. In case there isn't a 'cookbooks' entry, the normal flow would work.
