### PR TITLE
add support for all deploy_revision scm attributes

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -128,6 +128,18 @@ def run_deploy(force = false)
     group new_resource.group
     deploy_to new_resource.path
     ssh_wrapper "#{new_resource.path}/deploy-ssh-wrapper" if new_resource.deploy_key
+    
+    svn_username new_resource.svn_username if new_resource.svn_username
+    svn_arguments new_resource.svn_arguments if new_resource.svn_arguments
+    svn_password new_resource.svn_password if new_resource.svn_password
+    svn_info_args new_resource.svn_info_args if new_resource.svn_info_args
+    
+    
+    depth new_resource.git_depth if new_resource.git_depth
+    enable_submodules new_resource.git_enable_submodules if new_resource.git_enable_submodules
+    remote new_resource.git_remote if new_resource.git_remote
+    additional_remotes new_resource.git_additional_remotes if new_resource.git_additional_remotes
+
     shallow_clone true
     rollback_on_error new_resource.rollback_on_error
     all_environments = ([new_resource.environment]+new_resource.sub_resources.map{|res| res.environment}).inject({}){|acc, val| acc.merge(val)}

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -40,7 +40,22 @@ attribute :scm_provider, :kind_of => [Class, String, Symbol]
 attribute :revision, :kind_of => String
 attribute :repository, :kind_of => String
 attribute :environment, :kind_of => Hash, :default => {}
+
+# svn deploy resource attributes
+attribute :svn_username, :kind_of => [String, NilClass], :default => nil
+attribute :svn_password, :kind_of => [String, NilClass], :default => nil
+attribute :svn_arguments, :kind_of => [String, NilClass], :default => nil
+attribute :svn_info_args, :kind_of => [String, NilClass], :default => nil
+
+# git deploy resource attributes
 attribute :deploy_key, :kind_of => [String, NilClass], :default => nil
+attribute :git_depth, :kind_of => [String, NilClass], :default => nil
+attribute :git_enable_submodules, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :git_remote, :kind_of => [String, NilClass], :default => "origin"
+attribute :git_additional_remotes, :kind_of => Hash, :default => {}
+
+
+
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :rollback_on_error, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :purge_before_symlink, :kind_of => Array, :default => []


### PR DESCRIPTION
I needed to deploy from svn, using username/password, but I also added the missing git attributes (depth, enable_submodules, remote, additional_remotes) while I was at it.
