### PR TITLE
allow docroot to be subdirectory of deploy directory

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -33,6 +33,8 @@ actions :deploy, :force_deploy
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :environment_name, :kind_of => String, :default => (node.chef_environment =~ /_default/ ? "production" : node.chef_environment)
 attribute :path, :kind_of => String
+# docroot: set when the http docroot is a subdir of the deployed app
+attribute :docroot, :kind_of => [String, NilClass], :default => nil
 attribute :owner, :kind_of => String
 attribute :group, :kind_of => String
 attribute :strategy, :kind_of => [String, Symbol], :default => :deploy_revision


### PR DESCRIPTION
Adds a docroot attribute that the application_xxx cookbooks can use when the http docroot for an app is a subdir of the deployed app.

partially fixes http://tickets.opscode.com/browse/COOK-1487
