### PR TITLE
[COOK-1747] Add converge calling after recipe_eval for callbacks execution.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -155,7 +155,7 @@ class Chef
         case callback_code
         when Proc
           Chef::Log.info "#{@new_resource} running callback #{what}"
-          recipe_eval(&callback_code)
+          recipe_eval_and_converge(&callback_code)
         when String
           callback_file = "#{release_path}/#{callback_code}"
           unless ::File.exist?(callback_file)
@@ -173,11 +173,18 @@ class Chef
         if ::File.exist?(callback_file)
           Dir.chdir(release_path) do
             Chef::Log.info "#{@new_resource} running deploy hook #{callback_file}"
-            recipe_eval { from_file(callback_file) }
+            recipe_eval_and_converge { from_file(callback_file) }
           end
         end
       end
 
+
+      private
+
+      def recipe_eval_and_converge(&block)
+        recipe_eval(&block)
+        converge
+      end
     end
   end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1747

Callbacks are ignored unless you add call to 'converge' after recipe_eval.
