### PR TITLE
Fix resource not found for bug for custom lwrps

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,7 +20,7 @@
 
 require 'weakref'
 
-include Chef::DSL::IncludeRecipe
+include Chef::DSL::Recipe
 
 def initialize(*args)
   super


### PR DESCRIPTION
While creating a LWRP for use with opscode-cookbooks/application_php, I came across a bug resulting in "resource not found for [lwrpname]" in opscode-cookbooks/application.  The bug occurs when using a custom lwrp with a custom resource and provider.

I believe Chef::Mixin::RecipeDefinitionDSLCore should have been replaced with Chef::DSL::Recipe instead of Chef::DSL::IncludeRecipe.
