### PR TITLE
add option for strict ssh checking

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -100,7 +100,7 @@ def before_deploy
       owner new_resource.owner
       group new_resource.group
       mode "0755"
-      variables :id => new_resource.name, :deploy_to => new_resource.path
+      variables :id => new_resource.name, :deploy_to => new_resource.path, :strict_ssh => new_resource.strict_ssh
     end
   end
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -42,6 +42,7 @@ attribute :repository, :kind_of => String
 attribute :enable_submodules, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :environment, :kind_of => Hash, :default => {}
 attribute :deploy_key, :kind_of => [String, NilClass], :default => nil
+attribute :strict_ssh, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :shallow_clone, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :rollback_on_error, :kind_of => [TrueClass, FalseClass], :default => true

--- a/templates/default/deploy-ssh-wrapper.erb
+++ b/templates/default/deploy-ssh-wrapper.erb
@@ -5,4 +5,4 @@
 #
 # Rendered by Chef - local changes will be replaced
 
-/usr/bin/env ssh -o "StrictHostKeyChecking=no" -i "<%= @deploy_to %>/id_deploy" $@
+/usr/bin/env ssh <% unless @strict_ssh %>-o "StrictHostKeyChecking=no" <% end %>-i "<%= @deploy_to %>/id_deploy" $@


### PR DESCRIPTION
Add option for enforcing string SSH checking when using a deploy_key. Default action is false to maintain backward compatibility.
