### PR TITLE
Match `shallow_clone` default to deploy lwrp

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -44,7 +44,7 @@ attribute :enable_submodules, :kind_of => [TrueClass, FalseClass], :default => f
 attribute :environment, :kind_of => Hash, :default => {}
 attribute :deploy_key, :kind_of => [String, NilClass], :default => nil
 attribute :strict_ssh, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :shallow_clone, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :shallow_clone, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :rollback_on_error, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :purge_before_symlink, :kind_of => Array, :default => []


### PR DESCRIPTION
This fixes COOK-4733.

Because it's behavior is git is fragile, the `shallow_clone` option should be considered an advanced use case, and, in fact, it's not the default in the deploy LWRP. When this option was made configurable in COOK-2597, the default was unfortunately set to `true` rather than `false`.
